### PR TITLE
Fix issue on adding a new Cash Flow in Compute page.

### DIFF
--- a/NPVCalculator/Client/Pages/Compute.razor
+++ b/NPVCalculator/Client/Pages/Compute.razor
@@ -16,20 +16,20 @@
                 </div>
                 <div class="card-body slim-scroll">
 
-                    @foreach (KeyValuePair<int, decimal> cashflow in criteriaVM.CashFlows)
+                    @foreach(var cashFlow in criteriaVM.CashFlows)
                     {
                         <div class="media py-3 align-items-center justify-content-between">
                             <div class="d-flex rounded-circle align-items-center justify-content-center mr-3 media-icon iconbox-45 bg-primary text-white">
                                 <i class="mdi mdi-currency-php font-size-20"></i>
                             </div>
                             <div class="media-body pr-3 ">
-                                <label class="mt-0 mb-1 font-size-15 text-dark">@("₱" + cashflow.Value.ToString("#,#.##"))</label>
+                                <label class="mt-0 mb-1 font-size-15 text-dark">@("₱" + cashFlow.ToString("#,#.##"))</label>
                             </div>
                             <div>
-                                <button type="button" class="text-black-50 mr-2 font-size-20" @onclick="async () => await RemoveSelectedCashFlowAsync(cashflow.Key)" tooltip="Remove Cash Flow"><i class="mdi mdi-close-circle-outline font-size=20"></i></button>
+                                <button type="button" class="text-black-50 mr-2 font-size-20" @onclick="async () => await RemoveSelectedCashFlowAsync(cashFlow)" tooltip="Remove Cash Flow"><i class="mdi mdi-close-circle-outline font-size=20"></i></button>
                             </div>
                         </div>
-                    }
+                     }
                 </div>
             </div>
             <ValidationMessage For="@(() => criteriaVM.CashFlowHidden)" />
@@ -115,20 +115,19 @@
 
     private async Task AddCashFlowAsync()
     {
-        int cashFlowIndex = (criteriaVM.CashFlows.Count - 1);
-        criteriaVM.CashFlows.Add(cashFlowIndex + 1, Convert.ToDecimal(inputCashFlowVM.InputCashFlow));
-        criteriaVM.CashFlowHidden = string.Join(',', criteriaVM.CashFlows.Values);
+        criteriaVM.CashFlows.Add(new CashFlowViewModel(Convert.ToDecimal(inputCashFlowVM.InputCashFlow)));
+        criteriaVM.CashFlowHidden = string.Join(',', criteriaVM.CashFlows);
         inputCashFlowVM.InputCashFlow = "";
         StateHasChanged();
         await JSRuntime.InvokeVoidAsync("toggleModal", "cashFlowModal", "hide");
     }
 
-    private async Task RemoveSelectedCashFlowAsync(int index)
+    private async Task RemoveSelectedCashFlowAsync(CashFlowViewModel cashFlowVM)
     {
         await Task.Run(() =>
         {
-            criteriaVM.CashFlows.Remove(index);
-            criteriaVM.CashFlowHidden = criteriaVM.CashFlows.Count > 0 ? string.Join(',', criteriaVM.CashFlows.Values) : "";
+            criteriaVM.CashFlows.Remove(cashFlowVM);
+            criteriaVM.CashFlowHidden = criteriaVM.CashFlows.Count > 0 ? string.Join(',', criteriaVM.CashFlows) : "";
         });
 
     }

--- a/NPVCalculator/Client/ViewModels/CashFlowViewModel.cs
+++ b/NPVCalculator/Client/ViewModels/CashFlowViewModel.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NPVCalculator.Client.ViewModels
+{
+    public class CashFlowViewModel
+    {
+        public CashFlowViewModel(decimal cashFlow)
+        {
+            this.CashFlow = cashFlow;
+        }
+        public decimal CashFlow { get; set; }
+
+        public string ToString(string format)
+        {
+            return this.CashFlow.ToString(format);
+        }
+
+        public override string ToString()
+        {
+            return this.CashFlow.ToString();
+        }
+    }
+}

--- a/NPVCalculator/Client/ViewModels/CriteriaViewModel.cs
+++ b/NPVCalculator/Client/ViewModels/CriteriaViewModel.cs
@@ -10,7 +10,7 @@ namespace NPVCalculator.Client.ViewModels
     public class CriteriaViewModel
     {
         [Display(Name = "Cash Flows")]
-        public Dictionary<int, decimal> CashFlows { get; set; } = new Dictionary<int, decimal>();
+        public List<CashFlowViewModel> CashFlows { get; set; } = new List<CashFlowViewModel>();
         [Required(ErrorMessage = "Please enter at least one cash flow.")]
         public string CashFlowHidden { get; set; }
         [Required]
@@ -35,7 +35,7 @@ namespace NPVCalculator.Client.ViewModels
 
             var criteria = new NPVCriteria()
             {
-                CashFlows = string.Join(",", this.CashFlows.Values),
+                CashFlows = string.Join(",", this.CashFlows),
                 InitialValue = Convert.ToDecimal(this.InitialValue),
                 LowerBoundDiscountRate = Convert.ToDecimal(this.LowerBoundDiscountRate) / 100,
                 UpperBoundDiscountRate = Convert.ToDecimal(this.UpperBoundDiscountRate) / 100,


### PR DESCRIPTION
There is an issue when the user removed one cash flow from the list and inputted a new cash flow. Once the "Add New Cash Flow" button is clicked, nothing happens.

Did the following below to fix the issue:
- Added new view model class called CashFlowViewModel to store the cash flow values.
- Replaced the Dictionary<int, string> CashFlow property to List<CashFlowViewModel> CashFlow in CriteriaViewModel.
- Made modifications to Compute page and to CriteriaViewModel in order to use the CashViewModel instead of the previous Dictionary<int, string> CashFlow.